### PR TITLE
FIX/#8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ language: python
 dist: xenial
 python:
  - '2.7'
- - '3.4'
- - '3.5'
  - '3.6'
  - '3.7'
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: required
 language: python
 dist: xenial
 python:
- - '2.7'
  - '3.6'
  - '3.7'
 install:

--- a/rmageddon/lint.py
+++ b/rmageddon/lint.py
@@ -216,7 +216,7 @@ class RContainerLint(object):
             self.failed.append((3, "Could not find the \'r-base\' dependency."))
             return
 
-        # Check that every dependency has a version tag
+        # Check that every dependency has a version tag and that it's numerical
         dependencies = list([basepkg for basepkg in self.conda_config.get("dependencies")])
         for dependency in dependencies:
             strip = dependency.strip().split('=')

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 import sys
 
-version = '0.2.1'
+version = '0.2.2'
 
 with open('README.md') as f:
     readme = f.read()

--- a/tests/lint_examples/awesome_working_example/environment.yml
+++ b/tests/lint_examples/awesome_working_example/environment.yml
@@ -5,4 +5,4 @@ channels:
   - defaults
 dependencies:
   - r-base=3.4.3
-  - r-ggplot2
+  - r-ggplot2=3.2.0

--- a/tests/lint_examples/minimal_working_example/environment.yml
+++ b/tests/lint_examples/minimal_working_example/environment.yml
@@ -5,4 +5,4 @@ channels:
   - defaults
 dependencies:
   - r-base=3.4.3
-  - r-ggplot2
+  - r-ggplot2=3.2.0


### PR DESCRIPTION
Should solve https://github.com/qbicsoftware/rmageddon-cli/issues/8

@sven1103 could you very quickly glance over it, please?

I've disabled python 2, 3.4 and 3.5 support.     
Python 2 is dead and should finally die. I hope that no one here still uses it.

Since I'm a fan of fstrings and IIRC those come with python 3.6 I would also drop support for 3.4 and 3.5.
Python 3.6 is the default on all Linux distributions now and I don't think that there's any reason to use 3.4 or 3.5 with 3.8 already on the horizon.