### PR TITLE
Adding scripts and data as mandatory folders

### DIFF
--- a/rmageddon/lint.py
+++ b/rmageddon/lint.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+
 """ Linting code for QBiC R analysis environment
 checks.
 """
@@ -62,12 +63,16 @@ class RContainerLint(object):
 
         files_fail = [
             'Dockerfile',
-            'environment.yml',
-            'data',
-            'scripts'
+            'environment.yml'
         ]
+        
         files_warn = [
 
+        ]
+
+        folders_fail = [
+            'data',
+            'scripts'
         ]
 
         for files in files_fail:
@@ -81,6 +86,15 @@ class RContainerLint(object):
                 self.warned.append((1, 'Dir {} not found.'.format(files)))
             else:
                 self.passed.append((1, 'Dir {} found.'.format(files)))
+                
+        for folder in folders_fail:
+            if not os.path.isdir(self.pf(folder)):
+                self.failed.append((1, 'Dir {} not found.'.format(folder)))
+            elif len(os.listdir(self.pf(folder))) == 0 :
+                self.warned.append((1, 'Dir {} is empty.'.format(folder)))
+            else:
+                self.passed.append((1, 'Dir {} found.'.format(folder)))
+
 
         if os.path.isfile(self.pf('environment.yml')):
             self.load_environment_config()

--- a/rmageddon/lint.py
+++ b/rmageddon/lint.py
@@ -62,11 +62,12 @@ class RContainerLint(object):
 
         files_fail = [
             'Dockerfile',
-            'environment.yml'
-        ]
-        files_warn = [
+            'environment.yml',
             'data',
             'scripts'
+        ]
+        files_warn = [
+
         ]
 
         for files in files_fail:

--- a/rmageddon/lint.py
+++ b/rmageddon/lint.py
@@ -78,6 +78,7 @@ class RContainerLint(object):
         for files in files_fail:
             if not os.path.isfile(self.pf(files)):
                 self.failed.append((1, 'File {} not found.'.format(files)))
+               
             else:
                 self.passed.append((1, 'File {} found.'.format(files)))
 
@@ -90,7 +91,8 @@ class RContainerLint(object):
         for folder in folders_fail:
             if not os.path.isdir(self.pf(folder)):
                 self.failed.append((1, 'Dir {} not found.'.format(folder)))
-            elif len(os.listdir(self.pf(folder))) == 0 :
+              
+            elif len(os.listdir(self.pf(folder))) == 1 :
                 self.warned.append((1, 'Dir {} is empty.'.format(folder)))
             else:
                 self.passed.append((1, 'Dir {} found.'.format(folder)))

--- a/tests/environment.yml
+++ b/tests/environment.yml
@@ -6,5 +6,5 @@ channels:
 dependencies:
   - r-base=3.4.3
   - compiler-rt_osx-64=10.0.0=hbcc88fd_0
-  - gettext=0.19.8.1=h15daf44_
+
   - bioconductor-edger

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -63,7 +63,7 @@ class TestLint(unittest.TestCase):
         """
         lint_obj = lint.RContainerLint(PATH_MINIMAL_WORKING_EXAMPLE)
         lint_obj.lint_rproject()
-        expectations = {"failed": 0, "warned": 2, "passed": MAX_PASS_CHECKS - 2}
+        expectations = {"failed": 2, "warned": 2, "passed": MAX_PASS_CHECKS - 4}
         self.assess_lint_status(lint_obj, **expectations)
 
     def test_read_dir_ultimate_content_and_pass(self):
@@ -93,7 +93,7 @@ class TestLint(unittest.TestCase):
         """
         lint_obj = lint.RContainerLint(PATH_BAD_DOCKERFILE)
         lint_obj.lint_rproject()
-        expectations = {"failed": 2, "warned": 2, "passed": 1}
+        expectations = {"failed": 6, "warned": 0, "passed": 1}
         self.assess_lint_status(lint_obj, **expectations)
 
     def test_rpackage_empty_warn(self):
@@ -168,7 +168,7 @@ class TestLint(unittest.TestCase):
             """
         )
         lint_obj.check_conda_environment()
-        expectations = {"failed": 1, "warned": 2, "passed": 2}
+        expectations = {"failed": 5, "warned": 0, "passed": 2}
         self.assess_lint_status(lint_obj, **expectations)
 
     def test_conda_env_file_wrong_rversion_tag(self):
@@ -189,7 +189,7 @@ class TestLint(unittest.TestCase):
             """
         )
         lint_obj.check_conda_environment()
-        expectations = {"failed": 1, "warned": 2, "passed": 2}
+        expectations = {"failed": 5, "warned": 0, "passed": 2}
         self.assess_lint_status(lint_obj, **expectations)
 
     def test_missing_dependency_version(self):
@@ -210,7 +210,7 @@ class TestLint(unittest.TestCase):
             """
         )
         lint_obj.check_conda_environment()
-        expectations = {"failed": 1, "warned": 2, "passed": 2}
+        expectations = {"failed": 5, "warned": 0, "passed": 2}
         self.assess_lint_status(lint_obj, **expectations)
 
     def test_bad_dependency_signature(self):
@@ -231,5 +231,5 @@ class TestLint(unittest.TestCase):
             """
         )
         lint_obj.check_conda_environment()
-        expectations = {"failed": 1, "warned": 2, "passed": 2}
+        expectations = {"failed": 3, "warned": 0, "passed": 2}
         self.assess_lint_status(lint_obj, **expectations)

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -18,7 +18,6 @@ import unittest
 from ruamel.yaml import YAML
 import rmageddon.lint as lint
 
-
 def listfiles(path):
     files_found = []
     for (_, _, files) in os.walk(path):
@@ -59,11 +58,11 @@ class TestLint(unittest.TestCase):
             Minimal example for passing.
 
             Fails if not present: Dockerfile, environment.yml
-            Warns if not present: scripts, data
+            Warns if present and empty: scripts, data
         """
         lint_obj = lint.RContainerLint(PATH_MINIMAL_WORKING_EXAMPLE)
         lint_obj.lint_rproject()
-        expectations = {"failed": 2, "warned": 2, "passed": MAX_PASS_CHECKS - 4}
+        expectations = {"failed": 0, "warned": 2, "passed": MAX_PASS_CHECKS - 2}
         self.assess_lint_status(lint_obj, **expectations)
 
     def test_read_dir_ultimate_content_and_pass(self):
@@ -93,7 +92,7 @@ class TestLint(unittest.TestCase):
         """
         lint_obj = lint.RContainerLint(PATH_BAD_DOCKERFILE)
         lint_obj.lint_rproject()
-        expectations = {"failed": 6, "warned": 0, "passed": 1}
+        expectations = {"failed": 4, "warned": 0, "passed": 1}
         self.assess_lint_status(lint_obj, **expectations)
 
     def test_rpackage_empty_warn(self):
@@ -168,7 +167,7 @@ class TestLint(unittest.TestCase):
             """
         )
         lint_obj.check_conda_environment()
-        expectations = {"failed": 5, "warned": 0, "passed": 2}
+        expectations = {"failed": 3, "warned": 0, "passed": 2}
         self.assess_lint_status(lint_obj, **expectations)
 
     def test_conda_env_file_wrong_rversion_tag(self):
@@ -189,7 +188,7 @@ class TestLint(unittest.TestCase):
             """
         )
         lint_obj.check_conda_environment()
-        expectations = {"failed": 5, "warned": 0, "passed": 2}
+        expectations = {"failed": 3, "warned": 0, "passed": 2}
         self.assess_lint_status(lint_obj, **expectations)
 
     def test_missing_dependency_version(self):
@@ -210,7 +209,7 @@ class TestLint(unittest.TestCase):
             """
         )
         lint_obj.check_conda_environment()
-        expectations = {"failed": 5, "warned": 0, "passed": 2}
+        expectations = {"failed": 3, "warned": 0, "passed": 2}
         self.assess_lint_status(lint_obj, **expectations)
 
     def test_bad_dependency_signature(self):

--- a/{{cookiecutter.project_code}}/Dockerfile
+++ b/{{cookiecutter.project_code}}/Dockerfile
@@ -13,7 +13,10 @@ RUN apt-get update && apt-get install -y procps && apt-get clean -y
 # Update the base version of conda
 RUN conda update -n base conda
 # Copy the list of R packages into the container's /tmp dir
-COPY environment.yml /tmp
+WORKDIR /{{ cookiecutter.project_code }}
+COPY environment.yml /environment
+COPY scripts
+COPY data
 RUN conda update -n base conda && \
     conda env create -f /tmp/environment.yml && \
     conda clean -a


### PR DESCRIPTION
Hi there, here is the purpose of the PR :
- made the folders data and scripts mandatory, and modified the linting accordingly : 
* If the folders are present and contain files, the checks is passed
* If the folders are present and empty, it raises a warning,
* If absent, it fails.

I have modified the Dockerfile in order to have the data and scripts already present in the docker container. Longterm, I was thinking that at the end of a project we should just put all our scripts in scripts and the way to acces the data in data (maybe with the bash command or the qpostman command) and then upload the container in r-container of qbic.
Look forward to hearing your review!
best,
Laurence